### PR TITLE
Enhance OCR service with engine selection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+DATABASE_URL=postgresql://ocruser:ocrpass@db:5432/ocrdb
+REDIS_URL=redis://redis:6379/0
+STORAGE_PATH=/data
+BATCH_CRON=0 3 * * *
+BATCH_THRESHOLD=50
+X_USER_ID=admin
+GOOGLE_APPLICATION_CREDENTIALS=/secrets/gcloud.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+.env
+*.pyc
+*.pyo
+*.swp
+node_modules/
+.env.local
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# Chatgpt
+# OCR/HTR Document Digitization
+
+This repository contains a minimal skeleton to run an OCR/HTR service using FastAPI, Celery and React.
+
+## Quickstart
+
+1. Copy `.env.example` to `.env` and adjust variables if needed.
+2. Build and start the stack with Docker Compose:
+   ```bash
+   docker-compose up --build
+   ```
+3. Access the frontend at <http://localhost:3000>.
+
+The backend exposes endpoints for creating documents, uploading pages and exporting CSV/PDF. OCR jobs are processed asynchronously using Celery. The `ocr` module chooses between Tesseract and Google Vision depending on language and handwriting.
+
+The `.env` file also allows configuring credentials for Google Vision via `GOOGLE_APPLICATION_CREDENTIALS`.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY . /app
+RUN pip install fastapi uvicorn celery fpdf pytesseract google-cloud-vision
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/crud.py
+++ b/backend/crud.py
@@ -1,0 +1,73 @@
+"""Placeholder CRUD operations."""
+
+from typing import Optional
+from . import models
+
+# In-memory storage for example purposes
+DOCUMENTS = []
+PAGES = []
+
+def create_document(title: str, language: Optional[str], user_id: str):
+    doc_id = len(DOCUMENTS) + 1
+    doc = {"id": doc_id, "title": title, "language": language, "user_id": user_id}
+    DOCUMENTS.append(doc)
+    return doc
+
+def create_page(doc_id: int, page_number: int, path: str):
+    page_id = len(PAGES) + 1
+    page = {"id": page_id, "document_id": doc_id, "page_number": page_number, "path": path, "ocr_status": "pending"}
+    PAGES.append(page)
+    return page
+
+def export_document_csv(doc_id: int):
+    import io, csv
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow(["page_number", "text"])
+    for p in PAGES:
+        if p["document_id"] == doc_id:
+            writer.writerow([p["page_number"], f"text for page {p['id']}"])
+    output.seek(0)
+    return output
+
+def export_document_pdf(doc_id: int):
+    # placeholder PDF export
+    from fpdf import FPDF
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_font("Arial", size=12)
+    pdf.cell(0, 10, txt=f"Document {doc_id}")
+    for p in PAGES:
+        if p["document_id"] == doc_id:
+            pdf.cell(0, 10, txt=f"Page {p['page_number']} text")
+    import io
+    output = io.BytesIO()
+    pdf.output(output)
+    output.seek(0)
+    return output
+
+def get_page(page_id: int):
+    for p in PAGES:
+        if p["id"] == page_id:
+            return p
+    raise ValueError(f"page {page_id} not found")
+
+
+def get_document_language(doc_id: int) -> Optional[str]:
+    for d in DOCUMENTS:
+        if d["id"] == doc_id:
+            return d.get("language")
+    return None
+
+
+EXTRACTED_TEXT = []
+
+
+def save_extracted_text(page_id: int, text: str):
+    rec = {"page_id": page_id, "content": text}
+    EXTRACTED_TEXT.append(rec)
+    for p in PAGES:
+        if p["id"] == page_id:
+            p["ocr_status"] = "done"
+            break
+    return rec

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,51 @@
+from fastapi import FastAPI, UploadFile, File, Header, HTTPException
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
+from typing import List, Optional
+import uuid
+import shutil
+from . import crud
+from .ocr import STORAGE_PATH, enqueue_page
+
+app = FastAPI(title="Handwritten OCR Service")
+
+
+class DocumentIn(BaseModel):
+    title: str
+    language: Optional[str] = None
+
+
+class PageOut(BaseModel):
+    id: int
+    page_number: int
+    ocr_status: str
+
+
+@app.post("/documents/")
+async def create_document(doc: DocumentIn, x_user_id: str = Header(...)):
+    return crud.create_document(title=doc.title, language=doc.language, user_id=x_user_id)
+
+
+@app.post("/documents/{doc_id}/pages/", response_model=List[PageOut])
+async def upload_pages(doc_id: int, files: List[UploadFile] = File(...)):
+    pages = []
+    for num, f in enumerate(files, 1):
+        dest = f"{STORAGE_PATH}/{uuid.uuid4()}.png"
+        with open(dest, "wb") as out:
+            shutil.copyfileobj(f.file, out)
+        page = crud.create_page(doc_id, num, dest)
+        enqueue_page(page["id"])
+        pages.append(page)
+    return pages
+
+
+@app.get("/documents/{doc_id}/export/csv")
+async def export_csv(doc_id: int):
+    data = crud.export_document_csv(doc_id)
+    return StreamingResponse(data, media_type="text/csv")
+
+
+@app.get("/documents/{doc_id}/export/pdf")
+async def export_pdf(doc_id: int):
+    data = crud.export_document_pdf(doc_id)
+    return StreamingResponse(data, media_type="application/pdf")

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel
+from typing import Optional
+
+class Document(BaseModel):
+    id: int
+    title: str
+    language: Optional[str] = None
+    user_id: str
+
+class Page(BaseModel):
+    id: int
+    document_id: int
+    page_number: int
+    path: str
+    ocr_status: str

--- a/backend/ocr/__init__.py
+++ b/backend/ocr/__init__.py
@@ -1,0 +1,26 @@
+import os
+from pathlib import Path
+from . import engines
+from .. import crud
+
+STORAGE_PATH = os.environ.get("STORAGE_PATH", "/data")
+
+
+def run_ocr_job(page_id: int, engine: str = "auto") -> str:
+    """Run OCR job for the given page and return extracted text."""
+    page = crud.get_page(page_id)
+    lang = crud.get_document_language(page["document_id"])
+    if engine == "auto":
+        engine = engines.choose_engine(lang, handwriting=True)
+    image_path = Path(page["path"])
+    if engine == "tesseract":
+        text = engines.run_tesseract(image_path, lang or "eng")
+    elif engine == "google":
+        text = engines.run_google_vision(image_path)
+    else:
+        raise ValueError(f"Unknown engine {engine}")
+    crud.save_extracted_text(page_id, text)
+    return text
+
+
+from ..scheduler import enqueue_page

--- a/backend/ocr/engines.py
+++ b/backend/ocr/engines.py
@@ -1,0 +1,41 @@
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+try:
+    from google.cloud import vision
+except ImportError:  # pragma: no cover - google cloud optional
+    vision = None
+
+
+def run_tesseract(image_path: Path, lang: str = "eng") -> str:
+    """Run tesseract on the given image and return extracted text."""
+    result = subprocess.run([
+        "tesseract", str(image_path), "stdout", "-l", lang
+    ], capture_output=True, text=True, check=False)
+    return result.stdout
+
+
+def run_google_vision(image_path: Path) -> str:
+    """Use Google Vision API to extract text."""
+    if vision is None:
+        raise RuntimeError("google-cloud-vision not installed")
+    client = vision.ImageAnnotatorClient()
+    with open(image_path, "rb") as f:
+        content = f.read()
+    image = vision.Image(content=content)
+    response = client.text_detection(image=image)
+    if response.error.message:
+        raise RuntimeError(response.error.message)
+    return response.full_text_annotation.text
+
+
+def choose_engine(language: Optional[str], handwriting: bool = False) -> str:
+    """Simple engine selection based on language and handwriting flag."""
+    if handwriting:
+        # cloud engine recommended for handwriting
+        return "google"
+    if language and language.lower() not in {"en", "it"}:
+        # languages other than en/it use Google
+        return "google"
+    return "tesseract"

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -1,0 +1,18 @@
+import os
+from celery import Celery
+from .ocr import run_ocr_job
+
+CELERY_BROKER = os.environ.get("REDIS_URL", "redis://redis:6379/0")
+CELERY_BACKEND = os.environ.get("REDIS_URL", "redis://redis:6379/1")
+
+celery_app = Celery("tasks", broker=CELERY_BROKER, backend=CELERY_BACKEND)
+
+BATCH_THRESHOLD = int(os.environ.get("BATCH_THRESHOLD", "50"))
+
+@celery_app.task
+def process_page(page_id: int, engine: str):
+    run_ocr_job(page_id, engine)
+
+
+def enqueue_page(page_id: int, engine: str = "auto") -> None:
+    process_page.delay(page_id, engine)

--- a/db/init.sql
+++ b/db/init.sql
@@ -1,0 +1,44 @@
+CREATE TABLE documents (
+    id SERIAL PRIMARY KEY,
+    title TEXT NOT NULL,
+    language VARCHAR(10),
+    metadata JSONB,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE pages (
+    id SERIAL PRIMARY KEY,
+    document_id INTEGER REFERENCES documents(id) ON DELETE CASCADE,
+    page_number INTEGER NOT NULL,
+    image_path TEXT NOT NULL,
+    ocr_status VARCHAR(20) DEFAULT 'pending',
+    UNIQUE(document_id, page_number)
+);
+
+CREATE TABLE extracted_text (
+    id SERIAL PRIMARY KEY,
+    page_id INTEGER REFERENCES pages(id) ON DELETE CASCADE,
+    content TEXT,
+    metadata JSONB,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX idx_fulltext ON extracted_text USING GIN (to_tsvector('simple', content));
+
+CREATE TABLE ocr_jobs (
+    id SERIAL PRIMARY KEY,
+    page_id INTEGER REFERENCES pages(id) ON DELETE CASCADE,
+    engine VARCHAR(50),
+    started_at TIMESTAMP,
+    finished_at TIMESTAMP,
+    status VARCHAR(20)
+);
+
+CREATE TABLE user_edits (
+    id SERIAL PRIMARY KEY,
+    page_id INTEGER REFERENCES pages(id) ON DELETE CASCADE,
+    user_id TEXT NOT NULL,
+    field_changed TEXT,
+    old_value TEXT,
+    new_value TEXT,
+    edited_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: "3.9"
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: ocruser
+      POSTGRES_PASSWORD: ocrpass
+      POSTGRES_DB: ocrdb
+    volumes:
+      - db_data:/var/lib/postgresql/data
+  redis:
+    image: redis:7
+  backend:
+    build: ./backend
+    environment:
+      DATABASE_URL: postgres://ocruser:ocrpass@db:5432/ocrdb
+      REDIS_URL: redis://redis:6379/0
+      STORAGE_PATH: /data
+      GOOGLE_APPLICATION_CREDENTIALS: ${GOOGLE_APPLICATION_CREDENTIALS}
+    depends_on:
+      - db
+      - redis
+  frontend:
+    build: ./frontend
+    ports:
+      - "3000:80"
+    depends_on:
+      - backend
+volumes:
+  db_data:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:18-slim as build
+WORKDIR /app
+COPY . /app
+RUN echo "Placeholder build"
+
+FROM nginx:alpine
+COPY --from=build /app /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/src/components/ExportModal.tsx
+++ b/frontend/src/components/ExportModal.tsx
@@ -1,0 +1,13 @@
+import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+
+export function ExportModal({ open, onClose, onExportCSV, onExportPDF }) {
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent>
+        <Button onClick={onExportCSV}>Export CSV</Button>
+        <Button onClick={onExportPDF}>Export PDF</Button>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -1,0 +1,3 @@
+export function Button({ children, ...props }) {
+  return <button {...props}>{children}</button>;
+}

--- a/frontend/src/components/ui/data-table.tsx
+++ b/frontend/src/components/ui/data-table.tsx
@@ -1,0 +1,14 @@
+export function DataTable({ columns, data }) {
+  return (
+    <table>
+      <thead>
+        <tr>{columns.map(c => <th key={c}>{c}</th>)}</tr>
+      </thead>
+      <tbody>
+        {data?.map((row, i) => (
+          <tr key={i}>{columns.map(c => <td key={c}>{row[c]}</td>)}</tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -1,0 +1,15 @@
+export function Dialog({ open, onOpenChange, children }) {
+  if (!open) return null;
+  return (
+    <div className="dialog">
+      <div className="dialog-content">
+        {children}
+        <button onClick={() => onOpenChange(false)}>Close</button>
+      </div>
+    </div>
+  );
+}
+
+export function DialogContent({ children }) {
+  return <div>{children}</div>;
+}

--- a/frontend/src/pages/DocumentList.tsx
+++ b/frontend/src/pages/DocumentList.tsx
@@ -1,0 +1,20 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { DataTable } from "@/components/ui/data-table";
+
+export default function DocumentList() {
+  const { data, isLoading } = useQuery(["documents"], fetchDocuments);
+
+  if (isLoading) return <div>Loading...</div>;
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Documenti</h1>
+      <Link to="/upload">
+        <Button>Carica nuovo</Button>
+      </Link>
+      <DataTable columns={columns} data={data} />
+    </div>
+  );
+}

--- a/frontend/src/pages/UploadForm.tsx
+++ b/frontend/src/pages/UploadForm.tsx
@@ -1,0 +1,15 @@
+import { useMutation } from "@tanstack/react-query";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+
+export default function UploadForm() {
+  const [files, setFiles] = useState<FileList | null>(null);
+  const mutation = useMutation(uploadFiles);
+
+  return (
+    <form onSubmit={e => { e.preventDefault(); mutation.mutate(files); }}>
+      <input multiple type="file" onChange={e => setFiles(e.target.files)} />
+      <Button type="submit" disabled={mutation.isLoading}>Upload</Button>
+    </form>
+  );
+}

--- a/templates/document.html
+++ b/templates/document.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+  <meta charset="UTF-8">
+  <style>
+    body { font-family: Helvetica, Arial, sans-serif; }
+    table { width: 100%; border-collapse: collapse; }
+    th, td { border: 1px solid #ccc; padding: 4px; }
+  </style>
+</head>
+<body>
+  <h1>{{ title }}</h1>
+  <table>
+    <thead>
+      <tr><th>Pagina</th><th>Testo Estratto</th></tr>
+    </thead>
+    <tbody>
+      {% for page in pages %}
+      <tr>
+        <td>{{ page.number }}</td>
+        <td>{{ page.text }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add .gitignore and example Google credentials variable
- implement tesseract and Google Vision engines with selection logic
- extend OCR module to store extracted text
- load environment variables for Celery and scheduler
- adjust FastAPI endpoints with pydantic models
- document Google Vision setup in README
- fix imports to allow running as a package

## Testing
- `pytest -q`
- `uvicorn backend.main:app --reload` *(fails: ModuleNotFoundError: No module named 'celery')*

------
https://chatgpt.com/codex/tasks/task_e_684fcd7a72608328977b081a0205f0d6